### PR TITLE
cmd/kfulint,lint: minor changes to PR #1

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -2,20 +2,18 @@ package lint
 
 import "go/token"
 
-// Flags ...
-// TODO: Add description
-type Flags struct {
-}
-
 // Context ...
 // TODO: Add description
 type Context struct {
+	// FileSet is a file set that was used during package parsing.
 	FileSet *token.FileSet
-	Flags   *Flags
+
+	// PkgDir is a path to package being checked.
+	PkgDir string
 }
 
 // Checker ...
 // TODO: Add description
 type Checker interface {
-	Run(c *Context) error
+	Run(ctx *Context) error
 }


### PR DESCRIPTION
- Embed command-line args into lint.Context.
- Use context more extensively in kfulint/main.go

Not sure that we need `PkgDir` inside `lint.Context`, but the main idea is:
- Flags that are only needed inside main (for global configuration) are not part of `lint.Context`.
- Flags that are useful for checkers are embedded into `lint.Context` and it doesn't know that they are "command-line flags" (because it may make sense to fill them directly, in tests for example).

Flags like `PkgDir` can be a part of `Flags` type, but it should be defined in `cmd/kfulint`, not in `lint` (because command-line args are a property of executable program, not library).