### PR TITLE
lint: add param-name checker

### DIFF
--- a/cmd/kfulint/main.go
+++ b/cmd/kfulint/main.go
@@ -2,16 +2,46 @@ package main
 
 import (
 	"flag"
+	"go/ast"
+	"go/importer"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"log"
 	"os"
+	"sort"
+	"sync"
 
 	"github.com/PieselBois/kfulint/lint"
 )
 
-func checkers() []lint.Checker {
-	return []lint.Checker{}
+func main() {
+	log.SetFlags(0)
+
+	l := linter{
+		ctx: &lint.Context{
+			FileSet: token.NewFileSet(),
+		},
+		typesChecker: &types.Config{
+			Importer: importer.Default(),
+		},
+	}
+
+	parseArgv(&l)
+	pkgs := parseDir(l.ctx.FileSet, l.targetDir)
+
+	l.InitCheckers()
+	for _, pkg := range pkgs {
+		// TODO: if linters require ast.Package, assign it here.
+		files := sortedPackageFiles(pkg)
+		if err := l.CollectTypesInfo(files); err != nil {
+			log.Printf("skip %s: type check error: %v", pkg.Name, err)
+			continue
+		}
+		for _, f := range files {
+			l.CheckFile(f)
+		}
+	}
 }
 
 func blame(format string, args ...interface{}) {
@@ -22,32 +52,104 @@ func blame(format string, args ...interface{}) {
 
 // parseArgv processes command-line arguments and fills ctx argument with them.
 // Terminates program on error.
-func parseArgv(ctx *lint.Context) {
-	flag.StringVar(&ctx.PkgDir, "dir", "", "package directory")
-
-	if ctx.PkgDir == "" {
-		blame("Illegal empty -dir argument\n")
-	}
+func parseArgv(l *linter) {
+	flag.StringVar(&l.targetDir, "dir", "", "target package(s) directory")
 
 	flag.Parse()
+
+	if l.targetDir == "" {
+		blame("Illegal empty -dir argument\n")
+	}
 }
 
-func parsePackage(ctx *lint.Context) {
-	// TODO: save ParseDir results into ctx.
-	parser.ParseDir(ctx.FileSet, ctx.PkgDir, nil, parser.ParseComments)
+func parseDir(fset *token.FileSet, path string) []*ast.Package {
+	pkgMap, err := parser.ParseDir(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		log.Fatalf("parse dir error: %v", err)
+	}
+
+	var pkgList []*ast.Package
+	for _, pkg := range pkgMap {
+		pkgList = append(pkgList, pkg)
+	}
+
+	sort.Slice(pkgList, func(i, j int) bool {
+		return pkgList[i].Name < pkgList[j].Name
+	})
+	return pkgList
 }
 
-func main() {
-	ctx := lint.Context{
-		FileSet: token.NewFileSet(),
+func sortedPackageFiles(pkg *ast.Package) []*ast.File {
+	var files []*ast.File
+	for _, f := range pkg.Files {
+		files = append(files, f)
 	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name.Name < files[j].Name.Name
+	})
+	return files
+}
 
-	parseArgv(&ctx)
-	parsePackage(&ctx)
+type checker struct {
+	name string
+	lint.Checker
+}
 
-	for _, c := range checkers() {
-		if err := c.Run(&ctx); err != nil {
-			log.Print(err)
-		}
+type linter struct {
+	ctx *lint.Context
+
+	typesChecker *types.Config
+
+	checkers []checker
+
+	// Command line flags:
+
+	targetDir string
+}
+
+func (l *linter) InitCheckers() {
+	l.checkers = []checker{
+		{"param-name", lint.NewParamNameChecker(l.ctx)},
 	}
+}
+
+func (l *linter) CheckFile(f *ast.File) {
+	var wg sync.WaitGroup
+	wg.Add(len(l.checkers))
+	for _, c := range l.checkers {
+		// All checkers are expected to use *lint.Context
+		// as read-only structure, so no copying is required.
+		go func(c checker) {
+			defer func() {
+				wg.Done()
+				// Checker signals unexpected error with panic(error).
+				r := recover()
+				if r == nil {
+					return // There were no panic
+				}
+				if err, ok := r.(error); ok {
+					log.Printf("%s: error: %v\n", c.name, err)
+				} else {
+					// Some other kind of run-time panic.
+					// Undo the recover and resume panic.
+					panic(r)
+				}
+			}()
+			for _, w := range c.Check(f) {
+				pos := l.ctx.FileSet.Position(w.Node.Pos())
+				log.Printf("%s: %s/%s: %v\n", pos, c.name, w.Kind, w.Text)
+			}
+		}(c)
+	}
+	wg.Wait()
+}
+
+func (l *linter) CollectTypesInfo(files []*ast.File) error {
+	info := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+	}
+	l.ctx.TypesInfo = info
+	// TODO: if lint.Context needs types.Scope or types.Package, assign it here.
+	_, err := l.typesChecker.Check(l.targetDir, l.ctx.FileSet, files, info)
+	return err
 }

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -1,6 +1,23 @@
 package lint
 
-import "go/token"
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+)
+
+// WarkingKind describes checker warning category.
+// Useful for checkers that can find different kinds of issues.
+//
+// Should be human-readable, not cryptic.
+type WarningKind string
+
+// Warning represents issue found by checker.
+type Warning struct {
+	Kind WarningKind
+	Node ast.Node
+	Text string
+}
 
 // Context ...
 // TODO: Add description
@@ -8,12 +25,16 @@ type Context struct {
 	// FileSet is a file set that was used during package parsing.
 	FileSet *token.FileSet
 
-	// PkgDir is a path to package being checked.
-	PkgDir string
+	// TypesInfo carries parsed packages types information.
+	TypesInfo *types.Info
 }
 
-// Checker ...
-// TODO: Add description
+// Checker analyzes given file for potential issues.
+// Returns a list of linting errors.
+//
+// If checker encounters unexpected error, it should
+// signal it using panic with argument of "error" type,
+// but it should never call something like os.Exit or log.Fatal.
 type Checker interface {
-	Run(ctx *Context) error
+	Check(f *ast.File) []Warning
 }

--- a/lint/param-name_checker.go
+++ b/lint/param-name_checker.go
@@ -1,0 +1,87 @@
+package lint
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+)
+
+// ParamNameChecker detects potential issues in function parameter names.
+//
+// Rationale: makes godoc output better.
+type ParamNameChecker struct {
+	ctx *Context
+
+	loudNames map[string]bool
+
+	warnings []Warning
+}
+
+// NewParamNameChecker returns initialized checker for Go functions param names.
+func NewParamNameChecker(ctx *Context) *ParamNameChecker {
+	return &ParamNameChecker{
+		ctx: ctx,
+		loudNames: map[string]bool{
+			"IN":    true,
+			"OUT":   true,
+			"INOUT": true,
+		},
+	}
+}
+
+// Check runs parameter names checks for f.
+//
+// Features
+//
+// 1. Detects somewhat common "loud" identifiers, like IN or OUT.
+//    Suggests to replace them with down-case versions (in, out).
+//
+// 2. If capitalized name is not recognized as "loud",
+//    treat it as "redundantly exported".
+//    Suggests to use non-capitalized identifier.
+func (c *ParamNameChecker) Check(f *ast.File) []Warning {
+	c.warnings = c.warnings[:0]
+	for _, decl := range collectFuncDecls(f) {
+		for _, param := range c.collectFuncParams(decl) {
+			for _, id := range param.Names {
+				switch {
+				case c.loudNames[id.Name]:
+					c.warnLoud(id)
+				case ast.IsExported(id.Name):
+					c.warnCapitalized(id)
+				}
+			}
+		}
+	}
+	return c.warnings
+}
+
+func (c *ParamNameChecker) collectFuncParams(decl *ast.FuncDecl) []*ast.Field {
+	var params []*ast.Field
+	if decl.Recv != nil {
+		recv := decl.Recv.List[0]
+		params = append(params, recv)
+	}
+	params = append(params, decl.Type.Params.List...)
+	if decl.Type.Results != nil {
+		params = append(params, decl.Type.Results.List...)
+	}
+	return params
+}
+
+func (c *ParamNameChecker) warnCapitalized(id *ast.Ident) {
+	c.warnings = append(c.warnings, Warning{
+		Kind: "Capitalized",
+		Node: id,
+		Text: fmt.Sprintf("`%s' should not be capitalized", id),
+	})
+}
+
+func (c *ParamNameChecker) warnLoud(id *ast.Ident) {
+	c.warnings = append(c.warnings, Warning{
+		Kind: "Loud",
+		Node: id,
+		Text: fmt.Sprintf("consider `%s' name instead of `%s'",
+			strings.ToLower(id.Name), id),
+	})
+}

--- a/lint/util.go
+++ b/lint/util.go
@@ -1,0 +1,15 @@
+package lint
+
+import (
+	"go/ast"
+)
+
+func collectFuncDecls(f *ast.File) []*ast.FuncDecl {
+	var decls []*ast.FuncDecl
+	for _, decl := range f.Decls {
+		if decl, ok := decl.(*ast.FuncDecl); ok {
+			decls = append(decls, decl)
+		}
+	}
+	return decls
+}

--- a/testdata/foo.go
+++ b/testdata/foo.go
@@ -1,0 +1,13 @@
+package foo
+
+type paramNames struct{}
+
+func paramNamesLoud0(IN int) (OUT int) { return 0 }
+
+func (IN paramNames) Loud1(OUT *int) {}
+
+func paramNamesCapitalized0(X, Y int) {}
+
+func paramNamesCapitalized1(X int) (Y, Z int) { return 0, 0 }
+
+func (PN paramNames) Capitalized2() {}

--- a/testdata/foo_test.go
+++ b/testdata/foo_test.go
@@ -1,0 +1,1 @@
+package foo_test


### PR DESCRIPTION
Also modify kfulint/main.go and lint.go to make
it possible to implement first checker.