### PR TITLE
lint: add type-guard checker stub

### DIFF
--- a/cmd/kfulint/main.go
+++ b/cmd/kfulint/main.go
@@ -110,6 +110,7 @@ type linter struct {
 func (l *linter) InitCheckers() {
 	l.checkers = []checker{
 		{"param-name", lint.NewParamNameChecker(l.ctx)},
+		{"type-guard", lint.NewTypeGuardChecker(l.ctx)},
 	}
 }
 

--- a/lint/type-guard_checker.go
+++ b/lint/type-guard_checker.go
@@ -1,0 +1,23 @@
+package lint
+
+import (
+	"go/ast"
+)
+
+// TypeGuardChecker finds type switches that may benefit from type guard clause.
+//
+// Rationale: code readability.
+type TypeGuardChecker struct {
+	ctx *Context
+}
+
+// NewTypeGuardChecker returns initialized checker for Go type switch statements.
+func NewTypeGuardChecker(ctx *Context) *TypeGuardChecker {
+	return &TypeGuardChecker{ctx: ctx}
+}
+
+// Check runs type switch checks for f.
+func (c *TypeGuardChecker) Check(f *ast.File) []Warning {
+	// TODO: implement me. Refs #10.
+	return nil
+}


### PR DESCRIPTION
Adding stub now to avoid `main.go` conflicts after other linters appear.
Will roll implementations in near future.