### PR TITLE
Quasilyte/type guard v1

### DIFF
--- a/cmd/kfulint/main.go
+++ b/cmd/kfulint/main.go
@@ -138,7 +138,11 @@ func (l *linter) CheckFile(f *ast.File) {
 			}()
 			for _, w := range c.Check(f) {
 				pos := l.ctx.FileSet.Position(w.Node.Pos())
-				log.Printf("%s: %s/%s: %v\n", pos, c.name, w.Kind, w.Text)
+				name := c.name
+				if w.Kind != "" {
+					name += "/" + string(w.Kind)
+				}
+				log.Printf("%s: %s: %v\n", pos, name, w.Text)
 			}
 		}(c)
 	}

--- a/cmd/kfulint/main.go
+++ b/cmd/kfulint/main.go
@@ -151,7 +151,12 @@ func (l *linter) CheckFile(f *ast.File) {
 
 func (l *linter) CollectTypesInfo(files []*ast.File) error {
 	info := &types.Info{
-		Types: make(map[ast.Expr]types.TypeAndValue),
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Scopes:     make(map[ast.Node]*types.Scope),
 	}
 	l.ctx.TypesInfo = info
 	// TODO: if lint.Context needs types.Scope or types.Package, assign it here.

--- a/lint/internal/astfilter/astfilter.go
+++ b/lint/internal/astfilter/astfilter.go
@@ -1,0 +1,33 @@
+// Package astfilter provides composable filters and predicates for astutil package.
+package astfilter
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+// Or joins filters with OR operation and returns composed filter.
+// If any of filters return true, composed filter returns true.
+func Or(filters ...astutil.ApplyFunc) astutil.ApplyFunc {
+	return func(cur *astutil.Cursor) bool {
+		for _, f := range filters {
+			if f(cur) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// FuncDecl reports whether current node is *ast.FuncDecl.
+func FuncDecl(cur *astutil.Cursor) bool {
+	_, ok := cur.Node().(*ast.FuncDecl)
+	return ok
+}
+
+// Stmt reports whether current node is ast.Stmt.
+func Stmt(cur *astutil.Cursor) bool {
+	_, ok := cur.Node().(ast.Stmt)
+	return ok
+}

--- a/lint/type-guard_checker.go
+++ b/lint/type-guard_checker.go
@@ -36,7 +36,7 @@ func (c *TypeGuardChecker) Check(f *ast.File) []Warning {
 				c.check(stmt)
 				return false
 			}
-			return false
+			return true
 		})
 	}
 	return c.warnings
@@ -78,7 +78,7 @@ func (c *TypeGuardChecker) findTypeAssert(root ast.Stmt, expr, typ ast.Expr) boo
 				astcmp.EqualExpr(typ, assert.Type)
 			return !found
 		}
-		return false
+		return true
 	})
 	return found
 }

--- a/lint/type-guard_checker.go
+++ b/lint/type-guard_checker.go
@@ -28,12 +28,15 @@ func (c *TypeGuardChecker) Check(f *ast.File) []Warning {
 	// may have other type switches inside their clauses that
 	// can trigger warnings as well.
 	for _, decl := range collectFuncDecls(f) {
+		if decl.Body == nil {
+			continue
+		}
 		ast.Inspect(decl.Body, func(x ast.Node) bool {
 			if stmt, ok := x.(*ast.TypeSwitchStmt); ok {
 				c.check(stmt)
 				return false
 			}
-			return x != nil
+			return false
 		})
 	}
 	return c.warnings
@@ -75,7 +78,7 @@ func (c *TypeGuardChecker) findTypeAssert(root ast.Stmt, expr, typ ast.Expr) boo
 				astcmp.EqualExpr(typ, assert.Type)
 			return !found
 		}
-		return x != nil
+		return false
 	})
 	return found
 }

--- a/lint/type-guard_checker.go
+++ b/lint/type-guard_checker.go
@@ -73,10 +73,10 @@ func (c *TypeGuardChecker) checkTypeSwitch(root *ast.TypeSwitchStmt) {
 	}
 }
 
-func (c *TypeGuardChecker) warn(stmt *ast.TypeSwitchStmt, caseIndex int) {
+func (c *TypeGuardChecker) warn(node ast.Node, caseIndex int) {
 	s := "case %d can benefit from type switch with assignment"
 	c.warnings = append(c.warnings, Warning{
-		Node: stmt,
+		Node: node,
 		Text: fmt.Sprintf(s, caseIndex),
 	})
 }

--- a/lint/type-guard_checker.go
+++ b/lint/type-guard_checker.go
@@ -1,7 +1,10 @@
 package lint
 
 import (
+	"fmt"
 	"go/ast"
+
+	"github.com/Quasilyte/astcmp"
 )
 
 // TypeGuardChecker finds type switches that may benefit from type guard clause.
@@ -9,6 +12,8 @@ import (
 // Rationale: code readability.
 type TypeGuardChecker struct {
 	ctx *Context
+
+	warnings []Warning
 }
 
 // NewTypeGuardChecker returns initialized checker for Go type switch statements.
@@ -18,6 +23,67 @@ func NewTypeGuardChecker(ctx *Context) *TypeGuardChecker {
 
 // Check runs type switch checks for f.
 func (c *TypeGuardChecker) Check(f *ast.File) []Warning {
-	// TODO: implement me. Refs #10.
-	return nil
+	c.warnings = c.warnings[:0]
+	// TODO(quasilyte): do recursive analysis. Type switches
+	// may have other type switches inside their clauses that
+	// can trigger warnings as well.
+	for _, decl := range collectFuncDecls(f) {
+		ast.Inspect(decl.Body, func(x ast.Node) bool {
+			if stmt, ok := x.(*ast.TypeSwitchStmt); ok {
+				c.check(stmt)
+				return false
+			}
+			return x != nil
+		})
+	}
+	return c.warnings
+}
+
+func (c *TypeGuardChecker) check(root *ast.TypeSwitchStmt) {
+	if _, ok := root.Assign.(*ast.ExprStmt); !ok {
+		return
+	}
+	assert, ok := root.Assign.(*ast.ExprStmt).X.(*ast.TypeAssertExpr)
+	if !ok {
+		return
+	}
+
+	for i, clause := range root.Body.List {
+		clause := clause.(*ast.CaseClause)
+		// Multiple types in a list mean that assert.X will have
+		// a type of interface{} inside body.
+		// We are looking for precise type case.
+		if len(clause.List) != 1 {
+			continue
+		}
+		typ := clause.List[0]
+		for _, stmt := range clause.Body {
+			if c.findTypeAssert(stmt, assert.X, typ) {
+				c.warn(root, i)
+				break
+			}
+		}
+	}
+}
+
+func (c *TypeGuardChecker) findTypeAssert(root ast.Stmt, expr, typ ast.Expr) bool {
+	found := false
+	// TODO(quasilyte): inspect does not end the traverse after false is returned.
+	ast.Inspect(root, func(x ast.Node) bool {
+		if assert, ok := x.(*ast.TypeAssertExpr); ok {
+			found = astcmp.EqualExpr(expr, assert.X) &&
+				astcmp.EqualExpr(typ, assert.Type)
+			return !found
+		}
+		return x != nil
+	})
+	return found
+}
+
+func (c *TypeGuardChecker) warn(stmt *ast.TypeSwitchStmt, caseIndex int) {
+	s := "case %d can benefit from type switch with assignment"
+	c.warnings = append(c.warnings, Warning{
+		Node: stmt,
+		Text: fmt.Sprintf(s, caseIndex),
+	})
 }

--- a/lint/util.go
+++ b/lint/util.go
@@ -17,19 +17,6 @@ func collectFuncDecls(f *ast.File) []*ast.FuncDecl {
 	return decls
 }
 
-// inspectFuncBodies calls ast.Inspect for every non-empty function decl in f.
-//
-// Use if checker is only interested in statements or function-local expressions.
-func inspectFuncBodies(f *ast.File, visit func(ast.Node) bool) {
-	for _, decl := range f.Decls {
-		decl, ok := decl.(*ast.FuncDecl)
-		if !ok || decl.Body == nil {
-			continue
-		}
-		ast.Inspect(decl.Body, visit)
-	}
-}
-
 func nodeString(fset *token.FileSet, x ast.Node) string {
 	var buf bytes.Buffer
 	if err := printer.Fprint(&buf, fset, x); err == nil {

--- a/lint/util.go
+++ b/lint/util.go
@@ -13,3 +13,16 @@ func collectFuncDecls(f *ast.File) []*ast.FuncDecl {
 	}
 	return decls
 }
+
+// inspectFuncBodies calls ast.Inspect for every non-empty function decl in f.
+//
+// Use if checker is only interested in statements or function-local expressions.
+func inspectFuncBodies(f *ast.File, visit func(ast.Node) bool) {
+	for _, decl := range f.Decls {
+		decl, ok := decl.(*ast.FuncDecl)
+		if !ok || decl.Body == nil {
+			continue
+		}
+		ast.Inspect(decl.Body, visit)
+	}
+}

--- a/testdata/type-guard/checker_tests.go
+++ b/testdata/type-guard/checker_tests.go
@@ -1,4 +1,4 @@
-package linter_test
+package checker_test
 
 type point struct {
 	x int
@@ -54,6 +54,7 @@ func typeGuard2() int {
 }
 
 func typeGuard3(v interface{}) {
+	// Make sure that empty switches and case clauses do not crash the checker.
 	switch v.(type) {
 	case int:
 	case float32:
@@ -62,23 +63,43 @@ func typeGuard3(v interface{}) {
 	}
 }
 
+// Make sure that extern functions do not crash the checker.
 func typeGuard4()
 
-func typeGuard5(v interface{}) int {
-	switch v.(type) {
+func typeGuard5(x, y interface{}) int {
+	switch x.(type) {
 	case int:
-		return v.(int)
+		switch y.(type) {
+		case int:
+			// x shadows outer x, so checker should not trigger.
+			x := interface{}(1)
+			return x.(int) + y.(int)
+		}
 	case float32, float64:
-		switch v.(type) {
+		switch x.(type) {
 		case float32:
-			return int(v.(float32))
+			return int(x.(float32))
 		case float64:
-			return int(v.(float64))
+			return int(x.(float64))
 		}
 	default:
-		switch v.(type) {
+		switch x.(type) {
 		case int32:
-			return int(v.(int32))
+			return int(x.(int32))
+		}
+	}
+	return 0
+}
+
+func typeGuard6(x, y, z interface{}) int {
+	switch x.(type) {
+	case int:
+		switch y.(type) {
+		case int:
+			switch z.(type) {
+			case int:
+				return x.(int) + y.(int) + z.(int)
+			}
 		}
 	}
 	return 0

--- a/testdata/type-guard/main.go
+++ b/testdata/type-guard/main.go
@@ -63,3 +63,23 @@ func typeGuard3(v interface{}) {
 }
 
 func typeGuard4()
+
+func typeGuard5(v interface{}) int {
+	switch v.(type) {
+	case int:
+		return v.(int)
+	case float32, float64:
+		switch v.(type) {
+		case float32:
+			return int(v.(float32))
+		case float64:
+			return int(v.(float64))
+		}
+	default:
+		switch v.(type) {
+		case int32:
+			return int(v.(int32))
+		}
+	}
+	return 0
+}

--- a/testdata/type-guard/main.go
+++ b/testdata/type-guard/main.go
@@ -20,7 +20,7 @@ func typeGuard0() int {
 
 func typeGuard1() int {
 	xs := [][]interface{}{
-		[]interface{}{1, 2, 3},
+		{1, 2, 3},
 	}
 
 	switch xs[0][0].(type) {

--- a/testdata/type-guard/main.go
+++ b/testdata/type-guard/main.go
@@ -1,0 +1,54 @@
+package linter_test
+
+type point struct {
+	x int
+	y int
+}
+
+func typeGuard0() int {
+	var v interface{} = point{1, 2}
+
+	switch v.(type) {
+	case int:
+		return v.(int)
+	case point:
+		return v.(point).x + v.(point).y
+	default:
+		return 0
+	}
+}
+
+func typeGuard1() int {
+	xs := [][]interface{}{
+		[]interface{}{1, 2, 3},
+	}
+
+	switch xs[0][0].(type) {
+	default:
+		return 0
+	case []int:
+		return xs[0][0].([]int)[0]
+	}
+}
+
+func typeGuard2() int {
+	type nested struct {
+		a struct {
+			b struct {
+				value interface{}
+			}
+		}
+	}
+	var v nested
+	v.a.b.value = 10
+
+	switch v.a.b.value.(type) {
+	case int8, int16:
+		return 16
+	case int32:
+		return 32
+	case int:
+		return v.a.b.value.(int)
+	}
+	return 0
+}

--- a/testdata/type-guard/main.go
+++ b/testdata/type-guard/main.go
@@ -52,3 +52,14 @@ func typeGuard2() int {
 	}
 	return 0
 }
+
+func typeGuard3(v interface{}) {
+	switch v.(type) {
+	case int:
+	case float32:
+	}
+	switch v.(type) {
+	}
+}
+
+func typeGuard4()


### PR DESCRIPTION
Does trigger for cases from `testdata/type-guard`.
Does not handle nested type switches if containing type switch already triggered warning.
Will fix that later (todo is on it's place).