### PR TITLE
testdata: move tests to separate dirs

### DIFF
--- a/testdata/foo_test.go
+++ b/testdata/foo_test.go
@@ -1,1 +1,0 @@
-package foo_test

--- a/testdata/param-name/checker_tests.go
+++ b/testdata/param-name/checker_tests.go
@@ -1,4 +1,4 @@
-package foo
+package checker_test
 
 type paramNames struct{}
 
@@ -11,11 +11,3 @@ func paramNamesCapitalized0(X, Y int) {}
 func paramNamesCapitalized1(X int) (Y, Z int) { return 0, 0 }
 
 func (PN paramNames) Capitalized2() {}
-
-func badReturn() [](func()) {
-	return nil
-}
-
-func veryBadReturn() [](func([](func()))) {
-	return nil
-}

--- a/testdata/parenthesis/checker_tests.go
+++ b/testdata/parenthesis/checker_tests.go
@@ -1,0 +1,9 @@
+package checker_test
+
+func badReturn() [](func()) {
+	return nil
+}
+
+func veryBadReturn() [](func([](func()))) {
+	return nil
+}


### PR DESCRIPTION
The structure will be: `testdata/${checker-name}/checker_tests.go`.
The package name for each test suite is `checher_test`. It doesn't matter right now though.

Discussion is possible. :)