### PR TITLE
cmd/kfulint: add more param-duplication tests

### DIFF
--- a/cmd/kfulint/testdata/param-duplication/checker_tests.go
+++ b/cmd/kfulint/testdata/param-duplication/checker_tests.go
@@ -1,5 +1,45 @@
 package checker_test
 
+func good1(a, b int)                {}
+func good2(a, b int, c int32)       {}
+func good3(a, b, c int)             {}
+func good4(a int, b int32, c int64) {}
+func good5(a int)                   {}
+func good6()                        {}
+
 ///Duplication: a int, b int could be replaced with a, b int
 ///Duplication: b int, c int could be replaced with b, c int
-func duplicate(a int, b int, c int) {}
+func simple1(a int, b int, c int) {}
+
+//TODO: must trigger warning.
+func simple2() (a int, b int) { return 0, 0 }
+
+//TODO: must trigger warning.
+func simple3() (a int, b int, c int) { return 0, 0, 0 }
+
+///Duplication: a ,b int, c int could be replaced with a ,b, c int
+func mixedStyle1(a, b int, c int) {}
+
+///Duplication: a ,b int, c ,d int could be replaced with a ,b, c ,d int
+func mixedStyle2(a, b int, c, d int) {}
+
+///Duplication: a ,b ,c int, d int could be replaced with a ,b ,c, d int
+func mixedStyle3(a, b, c int, d int) {}
+
+///Duplication: a int, b ,c ,d int could be replaced with a, b ,c ,d int
+func mixedStyle4(a int, b, c, d int) {}
+
+///Duplication: a ,b int, c ,d int could be replaced with a ,b, c ,d int
+///Duplication: c ,d int, e ,f int could be replaced with c ,d, e ,f int
+///Duplication: e ,f int, g int could be replaced with e ,f, g int
+func mixedStyle5(a, b int, c, d int, e, f int, g int) {}
+
+//TODO: must trigger warning.
+func mixedStyle6() (a, b int, c int) { return 0, 0, 0 }
+
+//TODO: must trigger warning.
+func mixedStyle7() (a, b int, c, d int) { return 0, 0, 0, 0 }
+
+//TODO: should also handle output params (results).
+///Duplication: a int, b ,c int could be replaced with a, b ,c int
+func mixedStyle8(a int, b, c int) (d int, e int) { return a, c }


### PR DESCRIPTION
Added TODO cases, valid declarations that should not trigger warnings and tests for mixed arguments styles.