### PR TITLE
builtin-shadow_checker: add all predeclared identifiers

### DIFF
--- a/cmd/kfulint/testdata/builtin-shadow/checker_tests.go
+++ b/cmd/kfulint/testdata/builtin-shadow/checker_tests.go
@@ -1,63 +1,163 @@
 package checker_test
 
-func assigningToBuiltinFunctions() {
-	/// assigning to builtin function: append
+func assigningToBuiltinIdentifiers() {
+	// Types:
+	/// assigning to predeclared identifier: bool
+	bool := "1"
+	_ = bool
+
+	/// assigning to predeclared identifier: byte
+	byte := "1"
+	_ = byte
+
+	/// assigning to predeclared identifier: complex64
+	complex64 := "1"
+	_ = complex64
+
+	/// assigning to predeclared identifier: complex128
+	complex128 := "1"
+	_ = complex128
+
+	/// assigning to predeclared identifier: error
+	error := "1"
+	_ = error
+
+	/// assigning to predeclared identifier: float32
+	float32 := "1"
+	_ = float32
+
+	/// assigning to predeclared identifier: float64
+	float64 := "1"
+	_ = float64
+
+	/// assigning to predeclared identifier: int
+	int := "1"
+	_ = int
+
+	/// assigning to predeclared identifier: int8
+	int8 := "1"
+	_ = int8
+
+	/// assigning to predeclared identifier: int16
+	int16 := "1"
+	_ = int16
+
+	/// assigning to predeclared identifier: int32
+	int32 := "1"
+	_ = int32
+
+	/// assigning to predeclared identifier: int64
+	int64 := "1"
+	_ = int64
+
+	/// assigning to predeclared identifier: rune
+	rune := 10
+	_ = rune
+
+	/// assigning to predeclared identifier: string
+	string := 10
+	_ = string
+
+	/// assigning to predeclared identifier: uint
+	uint := "1"
+	_ = uint
+
+	/// assigning to predeclared identifier: uint8
+	uint8 := "1"
+	_ = uint8
+
+	/// assigning to predeclared identifier: uint16
+	uint16 := "1"
+	_ = uint16
+
+	/// assigning to predeclared identifier: uint32
+	uint32 := "1"
+	_ = uint32
+
+	/// assigning to predeclared identifier: uint64
+	uint64 := "1"
+	_ = uint64
+
+	/// assigning to predeclared identifier: uintptr
+	uintptr := "1"
+	_ = uintptr
+
+	// Constants:
+	/// assigning to predeclared identifier: true
+	true := "1"
+	_ = true
+
+	/// assigning to predeclared identifier: false
+	false := "1"
+	_ = false
+
+	/// assigning to predeclared identifier: iota
+	iota := "1"
+	_ = iota
+
+	// Zero value:
+	/// assigning to predeclared identifier: nil
+	nil := "1"
+	_ = nil
+
+	// Functions:
+	/// assigning to predeclared identifier: append
 	append := 1
 	_ = append
 
-	/// assigning to builtin function: cap
+	/// assigning to predeclared identifier: cap
 	cap := 1
 	_ = cap
 
-	/// assigning to builtin function: close
+	/// assigning to predeclared identifier: close
 	close := 1
 	_ = close
 
-	/// assigning to builtin function: complex
+	/// assigning to predeclared identifier: complex
 	complex := 1
 	_ = complex
 
-	/// assigning to builtin function: copy
+	/// assigning to predeclared identifier: copy
 	copy := 1
 	_ = copy
 
-	/// assigning to builtin function: delete
+	/// assigning to predeclared identifier: delete
 	delete := 1
 	_ = delete
 
-	/// assigning to builtin function: imag
+	/// assigning to predeclared identifier: imag
 	imag := 1
 	_ = imag
 
-	/// assigning to builtin function: len
+	/// assigning to predeclared identifier: len
 	len := 1
 	_ = len
 
-	/// assigning to builtin function: make
+	/// assigning to predeclared identifier: make
 	make := 1
 	_ = make
 
-	/// assigning to builtin function: new
+	/// assigning to predeclared identifier: new
 	new := 1
 	_ = new
 
-	/// assigning to builtin function: panic
+	/// assigning to predeclared identifier: panic
 	panic := 1
 	_ = panic
 
-	/// assigning to builtin function: print
+	/// assigning to predeclared identifier: print
 	print := 1
 	_ = print
 
-	/// assigning to builtin function: println
+	/// assigning to predeclared identifier: println
 	println := 1
 	_ = println
 
-	/// assigning to builtin function: real
+	/// assigning to predeclared identifier: real
 	real := 1
 	_ = real
 
-	/// assigning to builtin function: recover
+	/// assigning to predeclared identifier: recover
 	recover := 1
 	_ = recover
 }

--- a/lint/builtin-shadow_checker.go
+++ b/lint/builtin-shadow_checker.go
@@ -4,7 +4,8 @@ import (
 	"go/ast"
 )
 
-// builtinShadowCheck detects when builtin functions shadowed in assignments.
+// builtinShadowCheck detects when predeclared identifiers
+// shadowed in assignments.
 //
 // Rationale: avoid bugs.
 func builtinShadowCheck(ctx *context) func(*ast.File) {
@@ -12,6 +13,37 @@ func builtinShadowCheck(ctx *context) func(*ast.File) {
 		baseStmtChecker: baseStmtChecker{ctx: ctx},
 
 		builtins: map[string]bool{
+			// Types
+			"bool":       true,
+			"byte":       true,
+			"complex64":  true,
+			"complex128": true,
+			"error":      true,
+			"float32":    true,
+			"float64":    true,
+			"int":        true,
+			"int8":       true,
+			"int16":      true,
+			"int32":      true,
+			"int64":      true,
+			"rune":       true,
+			"string":     true,
+			"uint":       true,
+			"uint8":      true,
+			"uint16":     true,
+			"uint32":     true,
+			"uint64":     true,
+			"uintptr":    true,
+
+			// Constants
+			"true":  true,
+			"false": true,
+			"iota":  true,
+
+			// Zero value
+			"nil": true,
+
+			// Functions
 			"append":  true,
 			"cap":     true,
 			"close":   true,
@@ -49,5 +81,5 @@ func (c *builtinShadowChecker) CheckStmt(stmt ast.Stmt) {
 }
 
 func (c *builtinShadowChecker) warn(ident *ast.Ident) {
-	c.ctx.Warn(ident, "assigning to builtin function: %s", ident)
+	c.ctx.Warn(ident, "assigning to predeclared identifier: %s", ident)
 }


### PR DESCRIPTION
Fix #112