### PR TITLE
lint: fix builtin-shadow checker panic

### DIFF
--- a/cmd/kfulint/testdata/builtin-shadow/checker_tests.go
+++ b/cmd/kfulint/testdata/builtin-shadow/checker_tests.go
@@ -1,5 +1,17 @@
 package checker_test
 
+func noWarnigs() {
+	var foo struct {
+		len int
+		cap int
+	}
+
+	foo.len = 123
+	foo.cap = 321
+
+	foo.len, foo.cap = foo.cap, foo.len
+}
+
 func assigningToBuiltinIdentifiers() {
 	// Types:
 	/// assigning to predeclared identifier: bool

--- a/lint/builtin-shadow_checker.go
+++ b/lint/builtin-shadow_checker.go
@@ -72,7 +72,10 @@ type builtinShadowChecker struct {
 func (c *builtinShadowChecker) CheckStmt(stmt ast.Stmt) {
 	if assignStmt, ok := stmt.(*ast.AssignStmt); ok {
 		for _, v := range assignStmt.Lhs {
-			ident := v.(*ast.Ident)
+			ident, ok := v.(*ast.Ident)
+			if !ok {
+				continue
+			}
 			if _, isBuiltin := c.builtins[ident.Name]; isBuiltin {
 				c.warn(ident)
 			}


### PR DESCRIPTION
builtin-shadow checker panics when assign stmt LHS
is not *ast.Ident.

This can be reproduced by running it over GOROOT using lintwalk.

This patch fixes an issue and adds tests that check that
this issue remains fixed.