### PR TITLE
lint: do not use reference types in function parameters/results

### DIFF
--- a/cmd/kfulint/testdata/ptr-to-ref-param/negative_tests.go
+++ b/cmd/kfulint/testdata/ptr-to-ref-param/negative_tests.go
@@ -1,20 +1,20 @@
 package checker_test
 
-// OK: returned valus is not addressible, can't take address.
-func ok1(m map[int]string) (k chan float64) {
+// OK: regular reference types
+func ok1(m map[int]string, c []string) (k chan float64) {
 	return nil
 }
 
-/// OK: 1
+/// OK: just a regular chan
 func ok2(ch chan string) {}
 
-/// OK: 1231
+/// OK: fine
 func ok3(a *int, ch chan string) {}
 
-/// OK: 13123
+/// OK: pointers to underlaying types are acceptable
 func ok4(ch chan *string) chan *int {
 	return nil
 }
 
-/// OK: 131
+/// OK: just a func
 func ok5() {}

--- a/cmd/kfulint/testdata/ptr-to-ref-param/negative_tests.go
+++ b/cmd/kfulint/testdata/ptr-to-ref-param/negative_tests.go
@@ -1,0 +1,20 @@
+package checker_test
+
+// OK: returned valus is not addressible, can't take address.
+func ok1(m map[int]string) (k chan float64) {
+	return nil
+}
+
+/// OK: 1
+func ok2(ch chan string) {}
+
+/// OK: 1231
+func ok3(a *int, ch chan string) {}
+
+/// OK: 13123
+func ok4(ch chan *string) chan *int {
+	return nil
+}
+
+/// OK: 131
+func ok5() {}

--- a/cmd/kfulint/testdata/ptr-to-ref-param/positive_tests.go
+++ b/cmd/kfulint/testdata/ptr-to-ref-param/positive_tests.go
@@ -14,7 +14,7 @@ func f3(a int, m *map[int]string, s string) {}
 
 /// consider `ch' to be of non-pointer type
 /// consider `ch2' to be of non-pointer type
-func f4(ch *chan string) (ch2 *chan *int) {
+func f4(ch *[]string) (ch2 *chan *int) {
 	return nil
 }
 

--- a/cmd/kfulint/testdata/ptr-to-ref-param/positive_tests.go
+++ b/cmd/kfulint/testdata/ptr-to-ref-param/positive_tests.go
@@ -20,7 +20,7 @@ func f4(ch *[]string) (ch2 *chan *int) {
 
 /// consider `a' to be of non-pointer type
 /// consider `b' to be of non-pointer type
-/// consider to make returning type of non-pointer type
+/// consider to make non-pointer type for `*chan *int`
 func f5(a, b *chan string) *chan *int {
 	return nil
 }

--- a/cmd/kfulint/testdata/ptr-to-ref-param/positive_tests.go
+++ b/cmd/kfulint/testdata/ptr-to-ref-param/positive_tests.go
@@ -1,0 +1,36 @@
+package checker_test
+
+/// consider `m' to be of non-pointer type
+/// consider `k' to be of non-pointer type
+func f1(m *map[int]string) (k *chan float64) {
+	return nil
+}
+
+/// consider `ch' to be of non-pointer type
+func f2(ch *chan string) {}
+
+/// consider `m' to be of non-pointer type
+func f3(a int, m *map[int]string, s string) {}
+
+/// consider `ch' to be of non-pointer type
+/// consider `ch2' to be of non-pointer type
+func f4(ch *chan string) (ch2 *chan *int) {
+	return nil
+}
+
+/// consider `a' to be of non-pointer type
+/// consider `b' to be of non-pointer type
+/// consider to make returning type of non-pointer type
+func f5(a, b *chan string) *chan *int {
+	return nil
+}
+
+/// consider `a' to be of non-pointer type
+/// consider `b' to be of non-pointer type
+func f6(c int, a, b *chan string) {}
+
+/// consider `a' to be of non-pointer type
+/// consider `b' to be of non-pointer type
+func f7() (a, b *chan string) {
+	return nil, nil
+}

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -32,6 +32,7 @@ var checkFunctions = map[string]struct {
 	"builtin-shadow":    {new: builtinShadowCheck},
 	"range-expr-copy":   {new: rangeExprCopyCheck},
 	"stddef":            {new: stddefCheck},
+	"ptr-to-ref-param":  {new: ptrToRefTypeParamCheck},
 }
 
 // RuleList returns a slice of all rules that can be used to create checkers.

--- a/lint/ptr-to-ref-type-param_checker.go
+++ b/lint/ptr-to-ref-type-param_checker.go
@@ -16,9 +16,7 @@ type ptrToRefTypeParamChecker struct {
 }
 
 func (c *ptrToRefTypeParamChecker) CheckFuncDecl(fn *ast.FuncDecl) {
-	if fn.Type.Params != nil {
-		c.checkParams(fn.Type.Params.List)
-	}
+	c.checkParams(fn.Type.Params.List)
 	if fn.Type.Results != nil {
 		c.checkParams(fn.Type.Results.List)
 	}
@@ -33,7 +31,7 @@ func (c *ptrToRefTypeParamChecker) checkParams(params []*ast.Field) {
 
 		if isRefType(ptr.Elem().Underlying()) {
 			if len(param.Names) == 0 {
-				c.ctx.Warn(param, "consider to make returning type of non-pointer type")
+				c.ctx.Warn(param, "consider to make non-pointer type for `%s`", ptr.String())
 			} else {
 				for i := range param.Names {
 					c.warn(param.Names[i])

--- a/lint/ptr-to-ref-type-param_checker.go
+++ b/lint/ptr-to-ref-type-param_checker.go
@@ -49,7 +49,7 @@ func (c *ptrToRefTypeParamChecker) warn(id *ast.Ident) {
 
 func isRefType(x types.Type) bool {
 	switch x.(type) {
-	case *types.Map, *types.Chan:
+	case *types.Map, *types.Chan, *types.Slice:
 		return true
 	default:
 		return false

--- a/lint/ptr-to-ref-type-param_checker.go
+++ b/lint/ptr-to-ref-type-param_checker.go
@@ -1,0 +1,57 @@
+package lint
+
+import (
+	"go/ast"
+	"go/types"
+)
+
+func ptrToRefTypeParamCheck(ctx *context) func(*ast.File) {
+	return wrapFuncDeclChecker(&ptrToRefTypeParamChecker{
+		baseFuncDeclChecker: baseFuncDeclChecker{ctx: ctx},
+	})
+}
+
+type ptrToRefTypeParamChecker struct {
+	baseFuncDeclChecker
+}
+
+func (c *ptrToRefTypeParamChecker) CheckFuncDecl(fn *ast.FuncDecl) {
+	if fn.Type.Params != nil {
+		c.checkParams(fn.Type.Params.List)
+	}
+	if fn.Type.Results != nil {
+		c.checkParams(fn.Type.Results.List)
+	}
+}
+
+func (c *ptrToRefTypeParamChecker) checkParams(params []*ast.Field) {
+	for _, param := range params {
+		ptr, ok := c.ctx.TypesInfo.TypeOf(param.Type).(*types.Pointer)
+		if !ok {
+			continue
+		}
+
+		if isRefType(ptr.Elem().Underlying()) {
+			if len(param.Names) == 0 {
+				c.ctx.Warn(param, "consider to make returning type of non-pointer type")
+			} else {
+				for i := range param.Names {
+					c.warn(param.Names[i])
+				}
+			}
+		}
+	}
+}
+
+func (c *ptrToRefTypeParamChecker) warn(id *ast.Ident) {
+	c.ctx.Warn(id, "consider `%s' to be of non-pointer type", id)
+}
+
+func isRefType(x types.Type) bool {
+	switch x.(type) {
+	case *types.Map, *types.Chan:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Warn users when passing pointer to chan/map
```
func f(ch *chan string) (ch2 *chan *int) {
	return nil
}
```