### PR TITLE
lint: minor fixes to #146

### DIFF
--- a/cmd/kfulint/testdata/ptr-to-ref-param/positive_tests.go
+++ b/cmd/kfulint/testdata/ptr-to-ref-param/positive_tests.go
@@ -12,9 +12,9 @@ func f2(ch *chan string) {}
 /// consider `m' to be of non-pointer type
 func f3(a int, m *map[int]string, s string) {}
 
+/// consider `slice' to be of non-pointer type
 /// consider `ch' to be of non-pointer type
-/// consider `ch2' to be of non-pointer type
-func f4(ch *[]string) (ch2 *chan *int) {
+func f4(slice *[]string) (ch *chan *int) {
 	return nil
 }
 

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -32,7 +32,7 @@ var checkFunctions = map[string]struct {
 	"builtin-shadow":    {new: builtinShadowCheck},
 	"range-expr-copy":   {new: rangeExprCopyCheck},
 	"stddef":            {new: stddefCheck},
-	"ptr-to-ref-param":  {new: ptrToRefTypeParamCheck},
+	"ptr-to-ref-param":  {new: ptrToRefParamCheck},
 }
 
 // RuleList returns a slice of all rules that can be used to create checkers.

--- a/lint/ptr-to-ref-param_checker.go
+++ b/lint/ptr-to-ref-param_checker.go
@@ -5,31 +5,31 @@ import (
 	"go/types"
 )
 
-func ptrToRefTypeParamCheck(ctx *context) func(*ast.File) {
-	return wrapFuncDeclChecker(&ptrToRefTypeParamChecker{
+func ptrToRefParamCheck(ctx *context) func(*ast.File) {
+	return wrapFuncDeclChecker(&ptrToRefParamChecker{
 		baseFuncDeclChecker: baseFuncDeclChecker{ctx: ctx},
 	})
 }
 
-type ptrToRefTypeParamChecker struct {
+type ptrToRefParamChecker struct {
 	baseFuncDeclChecker
 }
 
-func (c *ptrToRefTypeParamChecker) CheckFuncDecl(fn *ast.FuncDecl) {
+func (c *ptrToRefParamChecker) CheckFuncDecl(fn *ast.FuncDecl) {
 	c.checkParams(fn.Type.Params.List)
 	if fn.Type.Results != nil {
 		c.checkParams(fn.Type.Results.List)
 	}
 }
 
-func (c *ptrToRefTypeParamChecker) checkParams(params []*ast.Field) {
+func (c *ptrToRefParamChecker) checkParams(params []*ast.Field) {
 	for _, param := range params {
 		ptr, ok := c.ctx.TypesInfo.TypeOf(param.Type).(*types.Pointer)
 		if !ok {
 			continue
 		}
 
-		if isRefType(ptr.Elem().Underlying()) {
+		if c.isRefType(ptr.Elem().Underlying()) {
 			if len(param.Names) == 0 {
 				c.ctx.Warn(param, "consider to make non-pointer type for `%s`", ptr.String())
 			} else {
@@ -41,15 +41,15 @@ func (c *ptrToRefTypeParamChecker) checkParams(params []*ast.Field) {
 	}
 }
 
-func (c *ptrToRefTypeParamChecker) warn(id *ast.Ident) {
-	c.ctx.Warn(id, "consider `%s' to be of non-pointer type", id)
-}
-
-func isRefType(x types.Type) bool {
+func (c *ptrToRefParamChecker) isRefType(x types.Type) bool {
 	switch x.(type) {
 	case *types.Map, *types.Chan, *types.Slice:
 		return true
 	default:
 		return false
 	}
+}
+
+func (c *ptrToRefParamChecker) warn(id *ast.Ident) {
+	c.ctx.Warn(id, "consider `%s' to be of non-pointer type", id)
 }


### PR DESCRIPTION
- Make checker type name (and filename) consistent with rule name
- Make referential type predicate function checker method.
  Not every checker may want to define slice as referential type.
- s/ch/slice/ for parameter which is slice (to avoid confusion)

Also, I've made nickname typo in branch name. :3